### PR TITLE
Add get_classification function

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/latloncover/CDL_subcategories.csv

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The function that summarizes land coverage can be used from multiple ways:
 - In python code
 
 ### Installation
-To use the command line `latloncover` tool or the python function requires installing the LatLonCover package.
+To use the command line `latloncover` tool or the python function requires installing the latloncover package.
 This can be done by running the following command:
 ```
-pip install git+https://github.com/Imageomics/LatLonCover.git
+pip install latloncover
 ```
 
 ### Command Line Interface
@@ -36,6 +36,7 @@ latloncover --help
 __add_classifications__(*df:pd.DataFrame, lat_col: str, lon_col: str*) -> *pd.DataFrame*
 
 > Returns a new dataframe with *_big and *_small land coverage columns added to df.
+> See [CDL_subcategories_legendCrse.csv](cropScapeDocumentation/CDL_subcategories_legendCrse.csv) for the list of column prefixes(Class) and their Definitions.
     
 Parameters:
 - __df__ - dataframe with latitude and longitude columns
@@ -44,7 +45,18 @@ Parameters:
 
 ----
 
-### Python Example
+__get_classification__(lat: number, lon: number) -> dictionary
+
+> Returns a dictionary with *_big and *_small land coverage data.
+> See [CDL_subcategories_legendCrse.csv](cropScapeDocumentation/CDL_subcategories_legendCrse.csv) for the list of column prefixes(Class) and their Definitions.
+
+Parameters:
+- __lat__ - decimal degree latitude
+- __lon__ - decimal degree longitude
+
+----
+
+### Python Examples
 
 The following python code will 
 1) read an input CSV file named `input.csv`
@@ -59,6 +71,15 @@ df = pd.read_csv("input.csv")
 df = latloncover.add_classifications(df, lat_col="Lat", lon_col="Lon")
 df.to_csv("output.csv", index=False)
 
+```
+
+----
+
+The following example prints landcoverage data for geocoordinate 36.0053695,-78.9469494.
+```python
+import latloncover
+landcoverage = latloncover.get_classification(36.0053695,-78.9469494)
+print(landcoverage)
 ```
 
 ## Data Sources

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ install_requires =
 package_dir=
     =src
 packages=find:
+include_package_data = True
 
 [options.packages.find]
 where=src

--- a/src/latloncover/CDL_subcategories.csv
+++ b/src/latloncover/CDL_subcategories.csv
@@ -1,0 +1,257 @@
+Codes,Class_Names,courseClass,fineClass
+0,Background,N,N
+1,Corn,A,A
+2,Cotton,A,A
+3,Rice,A,A
+4,Sorghum,A,A
+5,Soybeans,A,A
+6,Sunflower,A,A
+7,NA,N,N
+8,NA,N,N
+9,NA,N,N
+10,Peanuts,A,A
+11,Tobacco,A,A
+12,Sweet Corn,A,A
+13,Pop or Orn Corn,A,A
+14,Mint,A,A
+15,NA,N,N
+16,NA,N,N
+17,NA,N,N
+18,NA,N,N
+19,NA,N,N
+20,NA,N,N
+21,Barley,A,A
+22,Durum Wheat,A,A
+23,Spring Wheat,A,A
+24,Winter Wheat,A,A
+25,Other Small Grains,A,A
+26,Dbl Crop WinWht/Soybeans,A,AD
+27,Rye,A,A
+28,Oats,A,A
+29,Millet,A,A
+30,Speltz,A,A
+31,Canola,A,A
+32,Flaxseed,A,A
+33,Safflower,A,A
+34,Rape Seed,A,A
+35,Mustard,A,A
+36,Alfalfa,A,A
+37,Other Hay/Non Alfalfa,A,A
+38,Camelina,A,A
+39,Buckwheat,A,A
+40,NA,N,N
+41,Sugarbeets,A,A
+42,Dry Beans,A,A
+43,Potatoes,A,A
+44,Other Crops,A,A
+45,Sugarcane,A,A
+46,Sweet Potatoes,A,A
+47,Misc Vegs & Fruits,A,A
+48,Watermelons,A,A
+49,Onions,A,A
+50,Cucumbers,A,A
+51,Chick Peas,A,A
+52,Lentils,A,A
+53,Peas,A,A
+54,Tomatoes,A,A
+55,Caneberries,A,A
+56,Hops,A,A
+57,Herbs,A,A
+58,Clover/Wildflowers,A,A
+59,Sod/Grass Seed,G,G
+60,Switchgrass,G,G
+61,Fallow/Idle Cropland,A,AI
+62,NA,N,N
+63,Forest,F,F
+64,Shrubland,F,FS
+65,Barren,B,B
+66,Cherries,A,A
+67,Peaches,A,A
+68,Apples,A,A
+69,Grapes,A,A
+70,Christmas Trees,F,FE
+71,Other Tree Crops,F,F
+72,Citrus,A,A
+73,NA,N,N
+74,Pecans,A,A
+75,Almonds,A,A
+76,Walnuts,A,A
+77,Pears,A,A
+78,NA,N,N
+79,NA,N,N
+80,NA,N,N
+81,Clouds/No Data,N,N
+82,Developed,D,D
+83,Water,W,W
+84,NA,N,N
+85,NA,N,N
+86,NA,N,N
+87,Wetlands,WL,WL
+88,Nonag/Undefined,N,N
+89,NA,N,N
+90,NA,N,N
+91,NA,N,N
+92,Aquaculture,W,W
+93,NA,N,N
+94,NA,N,N
+95,NA,N,N
+96,NA,N,N
+97,NA,N,N
+98,NA,N,N
+99,NA,N,N
+100,NA,N,N
+101,NA,N,N
+102,NA,N,N
+103,NA,N,N
+104,NA,N,N
+105,NA,N,N
+106,NA,N,N
+107,NA,N,N
+108,NA,N,N
+109,NA,N,N
+110,NA,N,N
+111,Open Water,W,W
+112,Perennial Ice/Snow,W,WI
+113,NA,N,N
+114,NA,N,N
+115,NA,N,N
+116,NA,N,N
+117,NA,N,N
+118,NA,N,N
+119,NA,N,N
+120,NA,N,N
+121,Developed/Open Space,D,DR
+122,Developed/Low Intensity,D,DS
+123,Developed/Med Intensity,D,DS
+124,Developed/High Intensity,D,DH
+125,NA,N,N
+126,NA,N,N
+127,NA,N,N
+128,NA,N,N
+129,NA,N,N
+130,NA,N,N
+131,Barren,B,B
+132,NA,N,N
+133,NA,N,N
+134,NA,N,N
+135,NA,N,N
+136,NA,N,N
+137,NA,N,N
+138,NA,N,N
+139,NA,N,N
+140,NA,N,N
+141,Deciduous Forest,F,FD
+142,Evergreen Forest,F,FE
+143,Mixed Forest,F,F
+144,NA,N,N
+145,NA,N,N
+146,NA,N,N
+147,NA,N,N
+148,NA,N,N
+149,NA,N,N
+150,NA,N,N
+151,NA,N,N
+152,Shrubland,F,FS
+153,NA,N,N
+154,NA,N,N
+155,NA,N,N
+156,NA,N,N
+157,NA,N,N
+158,NA,N,N
+159,NA,N,N
+160,NA,N,N
+161,NA,N,N
+162,NA,N,N
+163,NA,N,N
+164,NA,N,N
+165,NA,N,N
+166,NA,N,N
+167,NA,N,N
+168,NA,N,N
+169,NA,N,N
+170,NA,N,N
+171,NA,N,N
+172,NA,N,N
+173,NA,N,N
+174,NA,N,N
+175,NA,N,N
+176,Grass/Pasture,G,G
+177,NA,N,N
+178,NA,N,N
+179,NA,N,N
+180,NA,N,N
+181,NA,N,N
+182,NA,N,N
+183,NA,N,N
+184,NA,N,N
+185,NA,N,N
+186,NA,N,N
+187,NA,N,N
+188,NA,N,N
+189,NA,N,N
+190,Woody Wetlands,WL,WLW
+191,NA,N,N
+192,NA,N,N
+193,NA,N,N
+194,NA,N,N
+195,Herbaceous Wetlands,WL,WLH
+196,NA,N,N
+197,NA,N,N
+198,NA,N,N
+199,NA,N,N
+200,NA,N,N
+201,NA,N,N
+202,NA,N,N
+203,NA,N,N
+204,Pistachios,A,A
+205,Triticale,A,A
+206,Carrots,A,A
+207,Asparagus,A,A
+208,Garlic,A,A
+209,Cantaloupes,A,A
+210,Prunes,A,A
+211,Olives,A,A
+212,Oranges,A,A
+213,Honeydew Melons,A,A
+214,Broccoli,A,A
+215,Avocados,A,A
+216,Peppers,A,A
+217,Pomegranates,A,A
+218,Nectarines,A,A
+219,Greens,A,A
+220,Plums,A,A
+221,Strawberries,A,A
+222,Squash,A,A
+223,Apricots,A,A
+224,Vetch,A,A
+225,Dbl Crop WinWht/Corn,A,AD
+226,Dbl Crop Oats/Corn,A,AD
+227,Lettuce,A,A
+228,Dbl Crop Triticale/Corn,A,AD
+229,Pumpkins,A,A
+230,Dbl Crop Lettuce/Durum Wht,A,AD
+231,Dbl Crop Lettuce/Cantaloupe,A,AD
+232,Dbl Crop Lettuce/Cotton,A,AD
+233,Dbl Crop Lettuce/Barley,A,AD
+234,Dbl Crop Durum Wht/Sorghum,A,AD
+235,Dbl Crop Barley/Sorghum,A,AD
+236,Dbl Crop WinWht/Sorghum,A,AD
+237,Dbl Crop Barley/Corn,A,AD
+238,Dbl Crop WinWht/Cotton,A,AD
+239,Dbl Crop Soybeans/Cotton,A,AD
+240,Dbl Crop Soybeans/Oats,A,AD
+241,Dbl Crop Corn/Soybeans,A,AD
+242,Blueberries,A,A
+243,Cabbage,A,A
+244,Cauliflower,A,A
+245,Celery,A,A
+246,Radishes,A,A
+247,Turnips,A,A
+248,Eggplants,A,A
+249,Gourds,A,A
+250,Cranberries,A,A
+251,NA,N,N
+252,NA,N,N
+253,NA,N,N
+254,Dbl Crop Barley/Soybeans,A,AD
+255,NA,N,N

--- a/src/latloncover/__init__.py
+++ b/src/latloncover/__init__.py
@@ -1,2 +1,2 @@
-from latloncover.classify import add_classifications
-__all__ = ['add_classifications']
+from latloncover.classify import add_classifications, get_classification
+__all__ = ['add_classifications', 'get_classification']

--- a/src/latloncover/main.py
+++ b/src/latloncover/main.py
@@ -11,7 +11,7 @@ from latloncover.classify import add_classifications
 def main(input, output, lat_col, lon_col):
     """
     Read INPUT CSV file, lookup land coverage data for a lat/lon column.
-    Write OUTPUT CSV file with additional columsn for fractional land coverage data.
+    Write OUTPUT CSV file with additional columns for fractional land coverage data.
     """
     print(f"Reading {input}.")
     df = pd.read_csv(input)

--- a/src/latloncover/tests/test_classify.py
+++ b/src/latloncover/tests/test_classify.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch, Mock
 import pandas as pd
-from latloncover.classify import add_classifications
+from latloncover.classify import add_classifications, get_classification, create_name_lookup
 
 CROPSPACE_XML = """
 <data>
@@ -51,3 +51,23 @@ class TestLatLonCov(unittest.TestCase):
         self.assertEqual(result['D_small'].to_list(), [0.1])
         # Same value for big since mock_requests.get always returns the same value
         self.assertEqual(result['D_big'].to_list(), [0.1])
+
+    @patch('latloncover.classify.add_classifications')
+    def test_get_classification(self, mock_add_classifications):
+        lat = 36.0053695
+        lon = 78.9469494
+        mock_add_classifications.return_value = pd.DataFrame.from_records([{
+            "A_big": 0.9,
+            "A_small": 0.7,
+            "lat": lat,
+            "lon": lon
+        }])
+        result = get_classification(lat=lat, lon=lon)
+        self.assertEqual(list(result.keys()), ["A_big", "A_small"])
+        self.assertEqual(result["A_big"], 0.9)
+        self.assertEqual(result["A_small"], 0.7)
+
+    def test_create_name_lookup(self):
+        name_lookup = create_name_lookup()
+        # Test known lookup value
+        self.assertEqual(name_lookup[1], "A")


### PR DESCRIPTION
Adds function to return classification dict for a single geocoordinate. Improves logic that loads the classification lookup by including CDL_subcategories.csv in the python package instead of downloading from GitHub. The previous
CDL_subcategories_legendCrse.csv location is maintained so that latloncover 0.0.1 will continue to work.

Fixes #11
Fixes #12